### PR TITLE
Feature/sign up

### DIFF
--- a/app/src/main/java/com/example/llm_project_android/Items.kt
+++ b/app/src/main/java/com/example/llm_project_android/Items.kt
@@ -1,6 +1,0 @@
-package com.example.llm_project_android
-
-data class Post(
-    var No: Int,           // 순서
-    var Product: String    // 상품명
-)

--- a/app/src/main/java/com/example/llm_project_android/Items.kt
+++ b/app/src/main/java/com/example/llm_project_android/Items.kt
@@ -1,0 +1,6 @@
+package com.example.llm_project_android
+
+data class Items(
+    var No: Int,           // 순서
+    var Product: String    // 상품명
+)

--- a/app/src/main/java/com/example/llm_project_android/Items.kt
+++ b/app/src/main/java/com/example/llm_project_android/Items.kt
@@ -1,6 +1,6 @@
 package com.example.llm_project_android
 
-data class Items(
+data class Post(
     var No: Int,           // 순서
     var Product: String    // 상품명
 )

--- a/app/src/main/java/com/example/llm_project_android/Post.kt
+++ b/app/src/main/java/com/example/llm_project_android/Post.kt
@@ -1,0 +1,5 @@
+package com.example.llm_project_android
+
+data class Post(
+    var title: String    // 상품명
+)

--- a/app/src/main/java/com/example/llm_project_android/PostContentAdapter.kt
+++ b/app/src/main/java/com/example/llm_project_android/PostContentAdapter.kt
@@ -1,0 +1,4 @@
+package com.example.llm_project_android
+
+class PostContentAdapter {
+}

--- a/app/src/main/java/com/example/llm_project_android/PostContentAdapter.kt
+++ b/app/src/main/java/com/example/llm_project_android/PostContentAdapter.kt
@@ -14,7 +14,7 @@ class PostContentAdapter (private var postList: List<Post>)
     : RecyclerView.Adapter<PostContentAdapter.PostViewHolder>(), Filterable {
 
     // 필터링 결과 리스트 (초기에는 전체 리스트와 동일)
-    private var filteredList: List<Post> = postList
+    private var filteredList: List<Post> = emptyList()
 
     // ViewHolder 정의: 아이템 레이아웃의 View들을 바인딩
     class PostViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
@@ -44,9 +44,9 @@ class PostContentAdapter (private var postList: List<Post>)
                 val result = FilterResults()
                 val queryStr = query?.toString() ?: ""  // 검색어 문자열로 변환
 
-                // 검색어가 비어있으면 전체 리스트 반환
-                val filtered = if (queryStr.isEmpty()){
-                    postList
+                // 검색어가 비어있으면 전체 리스트 반환 (공백일 경우)
+                val filtered = if (queryStr.isBlank()){
+                    emptyList<Post>()
                 } else {    // 검색어가 포함된 상품 필터링
                     postList.filter { post ->
                         post.title.contains(queryStr, ignoreCase = true)

--- a/app/src/main/java/com/example/llm_project_android/PostContentAdapter.kt
+++ b/app/src/main/java/com/example/llm_project_android/PostContentAdapter.kt
@@ -1,4 +1,68 @@
 package com.example.llm_project_android
 
-class PostContentAdapter {
+import android.annotation.SuppressLint
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Filter
+import android.widget.Filterable
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+
+class PostContentAdapter (private var postList: List<Post>)
+    : RecyclerView.Adapter<PostContentAdapter.PostViewHolder>(), Filterable {
+
+    // 필터링 결과 리스트 (초기에는 전체 리스트와 동일)
+    private var filteredList: List<Post> = postList
+
+    // ViewHolder 정의: 아이템 레이아웃의 View들을 바인딩
+    class PostViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        val title = itemView.findViewById<TextView>(R.id.text_title)
+    }
+
+    // ViewHolder 생성 (XML 레이아웃 inflate)
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PostViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.insurance_item_post, parent, false)
+        return PostViewHolder(view)
+    }
+
+    // 각 아이템에 데이터 바인딩
+    override fun onBindViewHolder(holder: PostViewHolder, position: Int) {
+        val post = filteredList[position]
+        holder.title.text = post.title
+    }
+
+    // 아이템 개수 반환
+    override fun getItemCount(): Int = filteredList.size
+
+    // 필터링 로직 구현
+    override fun getFilter(): Filter? {
+        return object : Filter() {
+            override fun performFiltering(query: CharSequence?): FilterResults {
+                val result = FilterResults()
+                val queryStr = query?.toString() ?: ""  // 검색어 문자열로 변환
+
+                // 검색어가 비어있으면 전체 리스트 반환
+                val filtered = if (queryStr.isEmpty()){
+                    postList
+                } else {    // 검색어가 포함된 상품 필터링
+                    postList.filter { post ->
+                        post.title.contains(queryStr, ignoreCase = true)
+                    }
+                }
+
+                result.values = filtered
+                return result
+            }
+
+            // 필터링 결과를 어댑터에 반영하고 새로고침
+            override fun publishResults(constraint: CharSequence?, results: FilterResults?) {
+                filteredList = results?.values as List<Post>
+                notifyDataSetChanged()
+            }
+        }
+    }
+
 }

--- a/app/src/main/java/com/example/llm_project_android/SignUpActivity1.kt
+++ b/app/src/main/java/com/example/llm_project_android/SignUpActivity1.kt
@@ -20,10 +20,20 @@ import kotlin.properties.Delegates
 class SignUpActivity1 : AppCompatActivity() {
 
     private lateinit var btn_next: Button
+    private lateinit var btn_idCheck: Button
+    private lateinit var btn_back: ImageButton
+    private lateinit var btn_eye:ImageButton
+    private lateinit var btn_eye_check: ImageButton
     private lateinit var id_text: EditText
     private lateinit var pw_text: EditText
     private lateinit var pw_check: EditText
     private lateinit var email_text: EditText
+    private lateinit var id_rule: TextView
+    private lateinit var pw_rule: TextView
+    private lateinit var pw_check_text: TextView
+    private lateinit var email_check: TextView
+
+
     var is_Id_Confirmed: Boolean by Delegates.observable(false) { _, _, _ -> updateNextButton() }        // 아이디 생성 완료 여부
     var is_Pw_Confirmed: Boolean by Delegates.observable(false) { _, _, _ -> updateNextButton() }        // 비밀번호 생성 완료 여부
     var is_Pw_Check_Confirmed: Boolean by Delegates.observable(false) { _, _, _ -> updateNextButton() }  // 비밀번호 확인 완료 여부
@@ -41,20 +51,20 @@ class SignUpActivity1 : AppCompatActivity() {
         }
 
         btn_next = findViewById<Button>(R.id.next_Button)               // 다음 버튼
-        val btn_back = findViewById<ImageButton>(R.id.backButton)       // 뒤로 가기 버튼
-        val btn_eye = findViewById<ImageButton>(R.id.eyeButton1)        // 비밀번호 시각화 버튼
-        val btn_eye_check = findViewById<ImageButton>(R.id.eyeButton2)  // 비밀번호 확인 시각화 버튼
-        val btn_idCheck = findViewById<Button>(R.id.checkButton)        // 아이디 중복 확인 버튼
+        btn_idCheck = findViewById<Button>(R.id.checkButton)            // 아이디 중복 확인 버튼
+        btn_back = findViewById<ImageButton>(R.id.backButton)           // 뒤로 가기 버튼
+        btn_eye = findViewById<ImageButton>(R.id.eyeButton1)            // 비밀번호 시각화 버튼
+        btn_eye_check = findViewById<ImageButton>(R.id.eyeButton2)      // 비밀번호 확인 시각화 버튼
 
         id_text = findViewById<EditText>(R.id.id_editText)              // 아이디 입력란
         pw_text = findViewById<EditText>(R.id.password_editText)        // 비밀번호 입력란
         pw_check = findViewById<EditText>(R.id.check_editText)          // 비밀번호 확인 입력란
         email_text = findViewById<EditText>(R.id.email_editText)        // 이메일 입력란
 
-        val id_rule = findViewById<TextView>(R.id.id_rule)              // 아이디 규칙 텍스트
-        val pw_rule = findViewById<TextView>(R.id.pw_rule)              // 비밀번호 규칙 텍스트
-        val pw_check_text = findViewById<TextView>(R.id.pw_check_text)  // 비밀번호 확인 여부 텍스트
-        val email_check = findViewById<TextView>(R.id.email_check)      // 이메일 확인 여부 텍스트
+        id_rule = findViewById<TextView>(R.id.id_rule)                  // 아이디 규칙 텍스트
+        pw_rule = findViewById<TextView>(R.id.pw_rule)                  // 비밀번호 규칙 텍스트
+        pw_check_text = findViewById<TextView>(R.id.pw_check_text)      // 비밀번호 확인 여부 텍스트
+        email_check = findViewById<TextView>(R.id.email_check)          // 이메일 확인 여부 텍스트
 
         val id_test: String = "qwer1234"            // 테스트 아이디
         var check_id: Boolean = false               // 아이디 중복 여부 (true: 존재, false: 비존재)

--- a/app/src/main/java/com/example/llm_project_android/SignUpActivity2.kt
+++ b/app/src/main/java/com/example/llm_project_android/SignUpActivity2.kt
@@ -27,10 +27,13 @@ import kotlin.text.isNullOrEmpty
 class SignUpActivity2 : AppCompatActivity() {
 
     private lateinit var btn_next: Button
+    private lateinit var btn_back: ImageButton
     private lateinit var name: EditText
     private lateinit var birth: EditText
     private lateinit var phone: EditText
     private lateinit var job_etc: EditText
+    private lateinit var married: RadioGroup
+    private lateinit var gender:RadioGroup
     private lateinit var gender_M: RadioButton
     private lateinit var gender_F: RadioButton
     private lateinit var married_N: RadioButton
@@ -57,19 +60,18 @@ class SignUpActivity2 : AppCompatActivity() {
         }
 
         btn_next = findViewById<Button>(R.id.next_Button)               // 다음 버튼
+        btn_back = findViewById<ImageButton>(R.id.backButton)           // 뒤로가기 버튼
         name = findViewById<EditText>(R.id.name_editText)               // 이름 입력란
         birth = findViewById<EditText>(R.id.birth_editText)             // 생년월일 입력란
         phone = findViewById<EditText>(R.id.phone_number_editText)      // 전화번호 입력란
+        married = findViewById<RadioGroup>(R.id.radioMaritalStatus)     // 결혼 여부 체크 그룹
+        gender = findViewById<RadioGroup>(R.id.radioGender)             // 성별 체크 그룹
         gender_M = findViewById<RadioButton>(R.id.radioMale)            // 성별 (남)
         gender_F = findViewById<RadioButton>(R.id.radioFemale)          // 성별 (여)
         married_N = findViewById<RadioButton>(R.id.radioSingle)         // 결혼여부 (미혼)
         married_Y = findViewById<RadioButton>(R.id.radioMarried)        // 결혼여부 (기혼)
         job_spinner = findViewById<Spinner>(R.id.job_spinner)           // 직업 드롭다운
         job_etc = findViewById<EditText>(R.id.job_etc)                  // 기타 직업 입력란
-
-        val btn_back = findViewById<ImageButton>(R.id.backButton)       // 뒤로가기 버튼
-        val married = findViewById<RadioGroup>(R.id.radioMaritalStatus) // 결혼 여부 체크 그룹
-        val gender = findViewById<RadioGroup>(R.id.radioGender)         // 성별 체크 그룹
 
         // 초기 설정 (버튼 비활성화)
         updateNextButton()

--- a/app/src/main/java/com/example/llm_project_android/SignUpActivity3.kt
+++ b/app/src/main/java/com/example/llm_project_android/SignUpActivity3.kt
@@ -60,7 +60,9 @@ class SignUpActivity3 : AppCompatActivity() {
         )
 
         // 이전 화면에서 데이터 받아오기
-        val data = getPassedStrings("id", "pw", "email", "source", "name", "birth", "phone", "gender", "married", "job")
+        val data = getPassedStrings(
+            "id", "pw", "email", "source",
+            "name", "birth", "phone", "gender", "married", "job")
 
         // 초기 설정 (버튼 비활성화)
         updateNextButton()
@@ -68,7 +70,7 @@ class SignUpActivity3 : AppCompatActivity() {
         // item 체크
         items_check({ is_Checked_Confirmed }, { is_Checked_Confirmed = it })
 
-        // 뒤로가기 버튼 클릭 이벤트 (to SignUpActivity1)
+        // 뒤로가기 버튼 클릭 이벤트 (to SignUpActivity2)
         clickBackButton(btn_back, data, SignUpActivity2::class.java)
 
         // 다음 버튼 클릭 이벤트 (to SignUpActivity4)

--- a/app/src/main/java/com/example/llm_project_android/SignUpActivity4.kt
+++ b/app/src/main/java/com/example/llm_project_android/SignUpActivity4.kt
@@ -1,7 +1,9 @@
 package com.example.llm_project_android
 
 import android.os.Bundle
+import android.widget.Button
 import android.widget.EditText
+import android.widget.ImageButton
 import android.widget.RadioButton
 import android.widget.RadioGroup
 import androidx.activity.enableEdgeToEdge
@@ -13,11 +15,15 @@ import com.google.android.material.chip.ChipGroup
 
 class SignUpActivity4 : AppCompatActivity() {
 
+    private lateinit var btn_back: ImageButton
+    private lateinit var btn_clear: ImageButton
+    private lateinit var btn_next: Button
+    private lateinit var insurance_layout: ConstraintLayout
     private lateinit var insurance: RadioGroup
     private lateinit var insurance_Y: RadioButton
     private lateinit var insurance_N: RadioButton
     private lateinit var search_insurance: EditText
-    private lateinit var tag: ChipGroup
+    private lateinit var tag_chip: ChipGroup
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -28,5 +34,27 @@ class SignUpActivity4 : AppCompatActivity() {
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
             insets
         }
+
+//        btn_back: ImageButton
+//        btn_clear: ImageButton
+//        btn_next: Button
+//        private lateinit var insurance: RadioGroup
+//        private lateinit var insurance_Y: RadioButton
+//        private lateinit var insurance_N: RadioButton
+//        private lateinit var search_insurance: EditText
+//        private lateinit var tag_chip: ChipGroup
+
+        btn_back = findViewById<ImageButton>(R.id.backButton)
+        btn_clear = findViewById<ImageButton>(R.id.text_clear)
+        btn_next = findViewById<Button>(R.id.next_Button)
+        insurance_layout = findViewById<ConstraintLayout>(R.id.insurance_layout)
+        insurance = findViewById<RadioGroup>(R.id.radioInsurance)
+        insurance_Y = findViewById<RadioButton>(R.id.insuranceYes)
+        insurance_N = findViewById<RadioButton>(R.id.insuranceNo)
+        search_insurance = findViewById<EditText>(R.id.search_insurance)
+        tag_chip = findViewById<ChipGroup>(R.id.tagChipGroup)
+
+
+
     }
 }

--- a/app/src/main/java/com/example/llm_project_android/SignUpActivity4.kt
+++ b/app/src/main/java/com/example/llm_project_android/SignUpActivity4.kt
@@ -7,6 +7,9 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 
 class SignUpActivity4 : AppCompatActivity() {
+
+    private lateinit var insurance_Group
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()

--- a/app/src/main/java/com/example/llm_project_android/SignUpActivity4.kt
+++ b/app/src/main/java/com/example/llm_project_android/SignUpActivity4.kt
@@ -1,14 +1,23 @@
 package com.example.llm_project_android
 
 import android.os.Bundle
+import android.widget.EditText
+import android.widget.RadioButton
+import android.widget.RadioGroup
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import com.google.android.material.chip.ChipGroup
 
 class SignUpActivity4 : AppCompatActivity() {
 
-    private lateinit var insurance_Group
+    private lateinit var insurance: RadioGroup
+    private lateinit var insurance_Y: RadioButton
+    private lateinit var insurance_N: RadioButton
+    private lateinit var search_insurance: EditText
+    private lateinit var tag: ChipGroup
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/example/llm_project_android/SignUpActivity4.kt
+++ b/app/src/main/java/com/example/llm_project_android/SignUpActivity4.kt
@@ -65,10 +65,35 @@ class SignUpActivity4 : AppCompatActivity() {
         // 초기 설정 (버튼 비활성화)
         updateCompletionButton()
 
+        var searchViewTextListner : SearchView.OnQueryTextListener =
+            object :SearchView.OnQueryTextListener {
+                //검색버튼 입력시 호출하는데, 지금은 검색버튼이 없으므로 사용x
+                override fun onQueryTextSubmit(query: String?): Boolean {
+                    return false
+                }
+
+                //텍스트 입력/수정 시 호출
+                override fun onQueryTextChange(s: String?): Boolean {
+                    recyclerView!!.filter.filter(s)
+                    return false
+                }
+
+            }
+
         // 뒤로가기 버튼 클릭 이벤트 (to SignUpActivity3)
         clickBackButton(btn_back, data, SignUpActivity3::class.java)
 
 
+    }
+
+    fun temp() : ArrayList<Post> {
+        var t = ArrayList<Post>()
+        t.add(Post(1, "wpqkf@gmail.com"))
+        t.add(Post(2, "ehofk@gmail.com"))
+        t.add(Post(3, "gngk@gmail.com"))
+        t.add(Post(4, "gmgl@gmail.com"))
+
+        return t
     }
 
     // 검색어 입력 함수

--- a/app/src/main/java/com/example/llm_project_android/SignUpActivity4.kt
+++ b/app/src/main/java/com/example/llm_project_android/SignUpActivity4.kt
@@ -29,8 +29,7 @@ class SignUpActivity4 : AppCompatActivity() {
     private lateinit var search_insurance: SearchView
     private lateinit var tag_chip: ChipGroup
     private lateinit var recyclerView: RecyclerView
-
-    var ArrayList<SingleItem>
+    private lateinit var adapter: PostContentAdapter
 
     var is_Check_Confirmed: Boolean by Delegates.observable(false) { _, _, _ -> updateCompletionButton() }        // 체크 완료 여부
     var is_Search_Confirmed: Boolean by Delegates.observable(false) { _, _, _ -> updateCompletionButton() }       // 체크 완료 여부
@@ -55,6 +54,7 @@ class SignUpActivity4 : AppCompatActivity() {
         search_insurance = findViewById<SearchView>(R.id.search_insurance)
         tag_chip = findViewById<ChipGroup>(R.id.tagChipGroup)
         recyclerView = findViewById<RecyclerView>(R.id.recyclerView)
+
 
         // 이전 화면에서 데이터 받아오기
         val data = getPassedStrings(

--- a/app/src/main/java/com/example/llm_project_android/SignUpActivity4.kt
+++ b/app/src/main/java/com/example/llm_project_android/SignUpActivity4.kt
@@ -1,29 +1,39 @@
 package com.example.llm_project_android
 
 import android.os.Bundle
+import android.view.View
 import android.widget.Button
 import android.widget.EditText
 import android.widget.ImageButton
 import android.widget.RadioButton
 import android.widget.RadioGroup
+import android.widget.SearchView
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.chip.ChipGroup
+import kotlin.properties.Delegates
 
 class SignUpActivity4 : AppCompatActivity() {
 
     private lateinit var btn_back: ImageButton
     private lateinit var btn_clear: ImageButton
-    private lateinit var btn_next: Button
+    private lateinit var btn_completion: Button
     private lateinit var insurance_layout: ConstraintLayout
     private lateinit var insurance: RadioGroup
     private lateinit var insurance_Y: RadioButton
     private lateinit var insurance_N: RadioButton
-    private lateinit var search_insurance: EditText
+    private lateinit var search_insurance: SearchView
     private lateinit var tag_chip: ChipGroup
+    private lateinit var recyclerView: RecyclerView
+
+    var ArrayList<SingleItem>
+
+    var is_Check_Confirmed: Boolean by Delegates.observable(false) { _, _, _ -> updateCompletionButton() }        // 체크 완료 여부
+    var is_Search_Confirmed: Boolean by Delegates.observable(false) { _, _, _ -> updateCompletionButton() }       // 체크 완료 여부
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -35,26 +45,70 @@ class SignUpActivity4 : AppCompatActivity() {
             insets
         }
 
-//        btn_back: ImageButton
-//        btn_clear: ImageButton
-//        btn_next: Button
-//        private lateinit var insurance: RadioGroup
-//        private lateinit var insurance_Y: RadioButton
-//        private lateinit var insurance_N: RadioButton
-//        private lateinit var search_insurance: EditText
-//        private lateinit var tag_chip: ChipGroup
-
         btn_back = findViewById<ImageButton>(R.id.backButton)
         btn_clear = findViewById<ImageButton>(R.id.text_clear)
-        btn_next = findViewById<Button>(R.id.next_Button)
+        btn_completion = findViewById<Button>(R.id.completion_Button)
         insurance_layout = findViewById<ConstraintLayout>(R.id.insurance_layout)
         insurance = findViewById<RadioGroup>(R.id.radioInsurance)
         insurance_Y = findViewById<RadioButton>(R.id.insuranceYes)
         insurance_N = findViewById<RadioButton>(R.id.insuranceNo)
-        search_insurance = findViewById<EditText>(R.id.search_insurance)
+        search_insurance = findViewById<SearchView>(R.id.search_insurance)
         tag_chip = findViewById<ChipGroup>(R.id.tagChipGroup)
+        recyclerView = findViewById<RecyclerView>(R.id.recyclerView)
+
+        // 이전 화면에서 데이터 받아오기
+        val data = getPassedStrings(
+            "id", "pw", "email", "source",
+            "name", "birth", "phone", "gender", "married", "job",
+            "disease0", "disease1", "disease2", "disease3", "disease4", "disease5", "disease6", "disease7", "disease8", "disease9")
+
+        // 초기 설정 (버튼 비활성화)
+        updateCompletionButton()
+
+        // 뒤로가기 버튼 클릭 이벤트 (to SignUpActivity3)
+        clickBackButton(btn_back, data, SignUpActivity3::class.java)
 
 
+    }
 
+    // 검색어 입력 함수
+    fun search_items(searchView: SearchView) {
+        var searchViewTextListener: SearchView.OnQueryTextListener =
+            object : SearchView.OnQueryTextListener {
+
+            }
+    }
+
+    // '완료' 버튼 활성화 함수
+    fun updateCompletionButton() {
+        if (true) {
+            btn_completion.isEnabled = true
+            btn_completion.setBackgroundResource(R.drawable.enabled_button)
+        } else {
+            btn_completion.isEnabled = false
+            btn_completion.setBackgroundResource(R.drawable.disabled_button)
+        }
+    }
+
+    // '뒤로가기' 버튼 클릭 이벤트 정의 함수
+    fun AppCompatActivity.clickBackButton(backButton: View, data: Map<String, Any>, targetActivity: Class<out AppCompatActivity>) {
+        backButton.setOnClickListener {
+            navigateTo(
+                targetActivity,
+                *data.mapValues { it.value }.toList().toTypedArray(),
+                reverseAnimation = true
+            )
+        }
+    }
+
+    // '완료' 버튼 클릭 이벤트 정의 함수
+    fun AppCompatActivity.clickCompletionButton(nextButton: View, data: Map<String, Any>, targetActivity: Class<out AppCompatActivity>) {
+        nextButton.setOnClickListener {
+            navigateTo(
+                targetActivity,
+                *data.mapValues { it.value }.toList().toTypedArray(),
+                "" to it
+            )
+        }
     }
 }

--- a/app/src/main/java/com/example/llm_project_android/SignUpActivity4.kt
+++ b/app/src/main/java/com/example/llm_project_android/SignUpActivity4.kt
@@ -3,26 +3,26 @@ package com.example.llm_project_android
 import android.os.Bundle
 import android.view.View
 import android.widget.Button
-import android.widget.EditText
 import android.widget.ImageButton
 import android.widget.RadioButton
 import android.widget.RadioGroup
-import android.widget.SearchView
+import androidx.appcompat.widget.SearchView
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.chip.ChipGroup
+import java.time.temporal.TemporalQuery
 import kotlin.properties.Delegates
 
 class SignUpActivity4 : AppCompatActivity() {
 
     private lateinit var btn_back: ImageButton
-    private lateinit var btn_clear: ImageButton
     private lateinit var btn_completion: Button
-    private lateinit var insurance_layout: ConstraintLayout
     private lateinit var insurance: RadioGroup
     private lateinit var insurance_Y: RadioButton
     private lateinit var insurance_N: RadioButton
@@ -45,9 +45,7 @@ class SignUpActivity4 : AppCompatActivity() {
         }
 
         btn_back = findViewById<ImageButton>(R.id.backButton)
-        btn_clear = findViewById<ImageButton>(R.id.text_clear)
         btn_completion = findViewById<Button>(R.id.completion_Button)
-        insurance_layout = findViewById<ConstraintLayout>(R.id.insurance_layout)
         insurance = findViewById<RadioGroup>(R.id.radioInsurance)
         insurance_Y = findViewById<RadioButton>(R.id.insuranceYes)
         insurance_N = findViewById<RadioButton>(R.id.insuranceNo)
@@ -55,6 +53,7 @@ class SignUpActivity4 : AppCompatActivity() {
         tag_chip = findViewById<ChipGroup>(R.id.tagChipGroup)
         recyclerView = findViewById<RecyclerView>(R.id.recyclerView)
 
+        val insuranceList = resources.getStringArray(R.array.insurances).map { Post(it) }   // 문자열 배열 -> Post 객체 리스트로 변환
 
         // 이전 화면에서 데이터 받아오기
         val data = getPassedStrings(
@@ -65,43 +64,30 @@ class SignUpActivity4 : AppCompatActivity() {
         // 초기 설정 (버튼 비활성화)
         updateCompletionButton()
 
-        var searchViewTextListner : SearchView.OnQueryTextListener =
-            object :SearchView.OnQueryTextListener {
-                //검색버튼 입력시 호출하는데, 지금은 검색버튼이 없으므로 사용x
-                override fun onQueryTextSubmit(query: String?): Boolean {
-                    return false
-                }
-
-                //텍스트 입력/수정 시 호출
-                override fun onQueryTextChange(s: String?): Boolean {
-                    recyclerView!!.filter.filter(s)
-                    return false
-                }
-
-            }
+        search_items(search_insurance, insuranceList)
 
         // 뒤로가기 버튼 클릭 이벤트 (to SignUpActivity3)
         clickBackButton(btn_back, data, SignUpActivity3::class.java)
-
-
-    }
-
-    fun temp() : ArrayList<Post> {
-        var t = ArrayList<Post>()
-        t.add(Post(1, "wpqkf@gmail.com"))
-        t.add(Post(2, "ehofk@gmail.com"))
-        t.add(Post(3, "gngk@gmail.com"))
-        t.add(Post(4, "gmgl@gmail.com"))
-
-        return t
     }
 
     // 검색어 입력 함수
-    fun search_items(searchView: SearchView) {
-        var searchViewTextListener: SearchView.OnQueryTextListener =
-            object : SearchView.OnQueryTextListener {
+    fun search_items(searchView: SearchView, insuranceList: List<Post>) {
+        // 어댑터 설정 및 RecyclerView 연결
+        adapter = PostContentAdapter(insuranceList)
+        recyclerView.layoutManager = LinearLayoutManager(this)
+        recyclerView.adapter = adapter
 
+        val dividerItemDecoration = DividerItemDecoration(this, LinearLayoutManager.VERTICAL)
+        recyclerView.addItemDecoration(dividerItemDecoration)
+
+        // 실시간 검색어 변경 감지 -> 필터 실행
+        searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
+            override fun onQueryTextSubmit(query: String?): Boolean = false
+            override fun onQueryTextChange(newText: String?): Boolean {
+                adapter.filter?.filter(newText)
+                return true
             }
+        })
     }
 
     // '완료' 버튼 활성화 함수

--- a/app/src/main/res/layout/insurance_item_post.xml
+++ b/app/src/main/res/layout/insurance_item_post.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/text_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="예시 제목"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/insurance_item_post.xml
+++ b/app/src/main/res/layout/insurance_item_post.xml
@@ -1,16 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content">
 
     <TextView
         android:id="@+id/text_title"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="예시 제목"
+        android:layout_height="50dp"
+        android:text="AIA 암 입원비 보험"
+        android:textSize="18dp"
+        android:gravity="center_vertical|left"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/sign_up_view4.xml
+++ b/app/src/main/res/layout/sign_up_view4.xml
@@ -143,12 +143,13 @@
                     app:layout_constraintTop_toTopOf="parent" />
 
                 <ImageButton
-                    android:id="@+id/eyeButton2"
+                    android:id="@+id/text_clear"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:background="@android:color/transparent"
-                    android:src="@drawable/resize_eye_visibility"
+                    android:src="@drawable/clear_button"
                     android:layout_marginRight="15dp"
+                    android:visibility="gone"
                     app:layout_constraintBottom_toBottomOf="@+id/search_insurance"
                     app:layout_constraintRight_toRightOf="@+id/search_insurance"
                     app:layout_constraintTop_toTopOf="@+id/search_insurance" />

--- a/app/src/main/res/layout/sign_up_view4.xml
+++ b/app/src/main/res/layout/sign_up_view4.xml
@@ -55,122 +55,100 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/title" />
 
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/constraintLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/subTitle_textView">
+
+        <TextView
+            android:id="@+id/insurance_textView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginHorizontal="30dp"
+            android:text="보험 가입 여부"
+            android:textColor="#000000"
+            android:textSize="18dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <RadioGroup
+            android:id="@+id/radioInsurance"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:layout_marginHorizontal="60dp"
+            android:orientation="horizontal"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <RadioButton
+                android:id="@+id/insuranceYes"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:text="  있음"
+                android:textSize="17dp"
+                android:checked="false" />
+
+            <RadioButton
+                android:id="@+id/insuranceNo"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:text="  없음"
+                android:textSize="17dp"
+                android:checked="true"/>
+        </RadioGroup>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.appcompat.widget.SearchView
+        android:id="@+id/search_insurance"
+        android:layout_width="match_parent"
+        android:layout_height="50dp"
+        android:focusable="true"
+        app:iconifiedByDefault="false"
+        android:textColorHint="#666666"
+        android:textSize="18dp"
+        app:queryHint="기존에 가입한 보혐명을 입력하세요"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/constraintLayout" />
+
+    <com.google.android.material.chip.ChipGroup
+        android:id="@+id/tagChipGroup"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="30dp"
+        app:singleSelection="false"
+        app:chipSpacing="8dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/search_insurance" />
+
     <ScrollView
         android:id="@+id/scrollView"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_marginTop="15dp"
-        app:layout_constraintBottom_toTopOf="@id/completion_Button"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="5dp"
         app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/subTitle_textView"
+        app:layout_constraintBottom_toTopOf="@id/completion_Button"
+        app:layout_constraintTop_toBottomOf="@+id/search_insurance"
         app:layout_constraintVertical_bias="0.0">
 
-        <LinearLayout
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerView"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical" >
-
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_marginTop="10dp">
-
-                <TextView
-                    android:id="@+id/insurance_textView"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:layout_marginHorizontal="30dp"
-                    android:text="보험 가입 여부"
-                    android:textColor="#000000"
-                    android:textSize="18dp"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-                <RadioGroup
-                    android:id="@+id/radioInsurance"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="end"
-                    android:layout_marginHorizontal="60dp"
-                    android:orientation="horizontal"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent">
-
-                    <RadioButton
-                        android:id="@+id/insuranceYes"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="20dp"
-                        android:text="  있음"
-                        android:textSize="17dp"
-                        android:checked="false" />
-
-                    <RadioButton
-                        android:id="@+id/insuranceNo"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="20dp"
-                        android:text="  없음"
-                        android:textSize="17dp"
-                        android:checked="true"/>
-                </RadioGroup>
-            </androidx.constraintlayout.widget.ConstraintLayout>
-
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/insurance_layout"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:layout_marginTop="15dp" >
-
-                <androidx.appcompat.widget.SearchView
-                    android:id="@+id/search_insurance"
-                    android:layout_width="match_parent"
-                    android:layout_height="50dp"
-                    android:layout_marginLeft="10dp"
-                    android:layout_marginRight="30dp"
-                    android:focusable="true"
-                    app:iconifiedByDefault="false"
-                    android:textColorHint="#666666"
-                    android:textSize="18dp"
-                    android:gravity="start|center_vertical"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintLeft_toLeftOf="parent"
-                    app:layout_constraintRight_toRightOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:queryHint="기존에 가입한 보혐명을 입력하세요" />
-
-                <ImageButton
-                    android:id="@+id/text_clear"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:background="@android:color/transparent"
-                    android:src="@drawable/clear_button"
-                    app:layout_constraintBottom_toBottomOf="@+id/search_insurance"
-                    app:layout_constraintRight_toRightOf="@+id/search_insurance"
-                    app:layout_constraintTop_toTopOf="@+id/search_insurance" />
-            </androidx.constraintlayout.widget.ConstraintLayout>
-
-            <com.google.android.material.chip.ChipGroup
-                android:id="@+id/tagChipGroup"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="30dp"
-                app:singleSelection="false"
-                app:chipSpacing="8dp"
-                android:visibility="gone" />
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/recyclerView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="30dp" />
-        </LinearLayout>
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="50dp" />
     </ScrollView>
 
     <androidx.appcompat.widget.AppCompatButton

--- a/app/src/main/res/layout/sign_up_view4.xml
+++ b/app/src/main/res/layout/sign_up_view4.xml
@@ -60,7 +60,7 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_marginTop="15dp"
-        app:layout_constraintBottom_toTopOf="@id/next_Button"
+        app:layout_constraintBottom_toTopOf="@id/completion_Button"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
@@ -107,7 +107,8 @@
                         android:layout_height="wrap_content"
                         android:layout_marginStart="20dp"
                         android:text="  있음"
-                        android:textSize="17dp" />
+                        android:textSize="17dp"
+                        android:checked="false" />
 
                     <RadioButton
                         android:id="@+id/insuranceNo"
@@ -115,7 +116,8 @@
                         android:layout_height="wrap_content"
                         android:layout_marginStart="20dp"
                         android:text="  없음"
-                        android:textSize="17dp" />
+                        android:textSize="17dp"
+                        android:checked="true"/>
                 </RadioGroup>
             </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -126,21 +128,22 @@
                 android:layout_gravity="center"
                 android:layout_marginTop="15dp" >
 
-                <EditText
+                <androidx.appcompat.widget.SearchView
                     android:id="@+id/search_insurance"
                     android:layout_width="match_parent"
                     android:layout_height="50dp"
-                    android:layout_marginHorizontal="30dp"
-                    android:background="@drawable/login_input_window"
-                    android:hint="기존에 가입한 보혐명을 입력하세요"
+                    android:layout_marginLeft="10dp"
+                    android:layout_marginRight="30dp"
+                    android:focusable="true"
+                    app:iconifiedByDefault="false"
                     android:textColorHint="#666666"
                     android:textSize="18dp"
-                    android:paddingStart="15dp"
                     android:gravity="start|center_vertical"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintLeft_toLeftOf="parent"
                     app:layout_constraintRight_toRightOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:queryHint="기존에 가입한 보혐명을 입력하세요" />
 
                 <ImageButton
                     android:id="@+id/text_clear"
@@ -148,14 +151,10 @@
                     android:layout_height="wrap_content"
                     android:background="@android:color/transparent"
                     android:src="@drawable/clear_button"
-                    android:layout_marginRight="15dp"
-                    android:visibility="gone"
                     app:layout_constraintBottom_toBottomOf="@+id/search_insurance"
                     app:layout_constraintRight_toRightOf="@+id/search_insurance"
                     app:layout_constraintTop_toTopOf="@+id/search_insurance" />
             </androidx.constraintlayout.widget.ConstraintLayout>
-
-
 
             <com.google.android.material.chip.ChipGroup
                 android:id="@+id/tagChipGroup"
@@ -163,38 +162,31 @@
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="30dp"
                 app:singleSelection="false"
-                app:chipSpacing="8dp" />
+                app:chipSpacing="8dp"
+                android:visibility="gone" />
 
-<!--            <androidx.recyclerview.widget.RecyclerView-->
-<!--                android:layout_width="match_parent"-->
-<!--                android:layout_height="200dp"-->
-<!--                android:layout_marginHorizontal="30dp"-->
-<!--                android:layout_marginTop="10dp">-->
-
-<!--                <TextView-->
-<!--                    android:id="@+id/itemText"-->
-<!--                    android:layout_width="match_parent"-->
-<!--                    android:layout_height="50dp"-->
-<!--                    android:gravity="center_vertical"-->
-<!--                    android:paddingHorizontal="16dp"-->
-<!--                    android:textColor="#000000" />-->
-<!--            </androidx.recyclerview.widget.RecyclerView>-->
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="30dp" />
         </LinearLayout>
     </ScrollView>
 
     <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/next_Button"
+        android:id="@+id/completion_Button"
         android:layout_width="350dp"
         android:layout_height="50dp"
         android:layout_gravity="center"
         android:layout_marginTop="40dp"
         android:layout_marginBottom="10dp"
-        android:background="@drawable/enabled_button"
+        android:background="@drawable/disabled_button"
         android:gravity="center"
         android:text="완 료"
         android:textColor="#FFFFFF"
         android:textSize="18dp"
         android:textStyle="bold"
+        android:enabled="false"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"/>

--- a/app/src/main/res/layout/sign_up_view4.xml
+++ b/app/src/main/res/layout/sign_up_view4.xml
@@ -120,43 +120,41 @@
             </androidx.constraintlayout.widget.ConstraintLayout>
 
             <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/insurance_Layout"
+                android:id="@+id/insurance_layout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginHorizontal="30dp"
-                android:layout_marginTop="10dp">
+                android:layout_gravity="center"
+                android:layout_marginTop="15dp" >
 
                 <EditText
                     android:id="@+id/search_insurance"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    app:layout_constraintVertical_weight="5"
-                    android:hint="기존 가입 보혐명 입력"
+                    android:layout_width="match_parent"
+                    android:layout_height="50dp"
+                    android:layout_marginHorizontal="30dp"
+                    android:background="@drawable/login_input_window"
+                    android:hint="기존에 가입한 보혐명을 입력하세요"
                     android:textColorHint="#666666"
+                    android:textSize="18dp"
+                    android:paddingStart="15dp"
+                    android:gravity="start|center_vertical"
                     app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintStart_toStartOf="@+id/insurance_Layout"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintEnd_toStartOf="@id/search_guideline"/>
-
-                <androidx.appcompat.widget.AppCompatButton
-                    android:layout_width="0dp"
-                    android:layout_height="40dp"
-                    android:text="검색"
-                    android:textColor="#FFFFFF"
-                    android:background="@drawable/enabled_button"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintVertical_weight="1"
-                    app:layout_constraintStart_toEndOf="@+id/search_guideline"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintRight_toRightOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
 
-                <androidx.constraintlayout.widget.Guideline
-                    android:id="@+id/search_guideline"
+                <ImageButton
+                    android:id="@+id/eyeButton2"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    app:layout_constraintGuide_percent="0.75" />
+                    android:background="@android:color/transparent"
+                    android:src="@drawable/resize_eye_visibility"
+                    android:layout_marginRight="15dp"
+                    app:layout_constraintBottom_toBottomOf="@+id/search_insurance"
+                    app:layout_constraintRight_toRightOf="@+id/search_insurance"
+                    app:layout_constraintTop_toTopOf="@+id/search_insurance" />
             </androidx.constraintlayout.widget.ConstraintLayout>
+
+
 
             <com.google.android.material.chip.ChipGroup
                 android:id="@+id/tagChipGroup"

--- a/app/src/main/res/values/array_insurances.xml
+++ b/app/src/main/res/values/array_insurances.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string-array name="jobs">
+        <item>---직업을 선택하세요---</item>
+        <item>AIA 암 입원비 보</item>
+        <item>삼성생명 종신보</item>
+        <item>한화생명 실손의료비보</item>
+        <item>교보생명 변액유니버셜보</item>
+        <item>DB손해보험 자동차보</item>
+        <item>현대해상 어린이보</item>
+        <item>메리츠화재 실손보</item>
+        <item>흥국화재 운전자보</item>
+        <item>롯데손해보험 건강보</item>
+        <item>KB손해보험 암보</item>
+        <item>NH농협생명 연금보</item>
+        <item>신한생명 종신보</item>
+        <item>동양생명 치아보</item>
+        <item>푸르덴셜생명 종신보</item>
+        <item>오렌지라이프 건강보</item>
+        <item>ABL생명 암보</item>
+    </string-array>
+
+</resources>

--- a/app/src/main/res/values/array_insurances.xml
+++ b/app/src/main/res/values/array_insurances.xml
@@ -1,24 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string-array name="jobs">
-        <item>---직업을 선택하세요---</item>
-        <item>AIA 암 입원비 보</item>
-        <item>삼성생명 종신보</item>
-        <item>한화생명 실손의료비보</item>
-        <item>교보생명 변액유니버셜보</item>
-        <item>DB손해보험 자동차보</item>
-        <item>현대해상 어린이보</item>
-        <item>메리츠화재 실손보</item>
-        <item>흥국화재 운전자보</item>
-        <item>롯데손해보험 건강보</item>
-        <item>KB손해보험 암보</item>
-        <item>NH농협생명 연금보</item>
-        <item>신한생명 종신보</item>
-        <item>동양생명 치아보</item>
-        <item>푸르덴셜생명 종신보</item>
-        <item>오렌지라이프 건강보</item>
-        <item>ABL생명 암보</item>
+    <string-array name="insurances">
+        <item>AIA 암 입원비 보험</item>
+        <item>삼성생명 종신보험</item>
+        <item>한화생명 실손의료비보험</item>
+        <item>교보생명 변액유니버셜보험</item>
+        <item>DB손해보험 자동차보험</item>
+        <item>현대해상 어린이보험</item>
+        <item>메리츠화재 실손보험</item>
+        <item>흥국화재 운전자보험</item>
+        <item>롯데손해보험 건강보험</item>
+        <item>KB손해보험 암보험</item>
+        <item>NH농협생명 연금보험</item>
+        <item>신한생명 종신보험</item>
+        <item>동양생명 치아보험</item>
+        <item>푸르덴셜생명 종신보험</item>
+        <item>오렌지라이프 건강보험</item>
+        <item>ABL생명 암보험</item>
     </string-array>
 
 </resources>


### PR DESCRIPTION
### 🛠️ 유틸리티 확장 (**`SignUpAcitivity3.kt`**)
- **items_check()**: 질병 관련 체크박스 입력 유효성 판별 함수 구현  
  - item0(질병 없음) 체크 시 나머지 항목 비활성화 및 자동 해제  
  - item0 해제 시 다른 항목 활성화  
  - item1~item9 중 하나라도 체크되면 is_Checked_Confirmed 값을 true로 갱신  
  - 모든 항목을 확인해 하나라도 체크된 경우 버튼 활성화 조건으로 활용
- **restorePassedData()**: 화면 복귀 시 체크박스 상태 복원 기능 구현  
  - disease0~disease9 상태를 불러와 체크박스 각각에 반영  
  - disease0이 true일 경우 나머지 항목 모두 비활성화 및 체크 해제
- **clickBackButton()**, **clickNextButton()**: 화면 간 데이터 이동을 위한 공통 처리 함수  
  - Map<String, Any> 형태로 문자열 및 불리언 값 동시 전달 가능

### ✨ 기능 추가 (**`SignUpAcitivity4.kt`**)

- **보험 검색 기능 (`search_items()`) 구현**
  - `SearchView`에서 검색어 입력 시 보험 리스트를 필터링하여 `RecyclerView`에 표시
  - 검색어가 비어있거나 공백만 있을 경우에는 빈 리스트를 반환하여 아무 항목도 표시하지 않음
  - `.filter.filter(query)`를 통해 실시간 반응 구현
- **RecyclerView 아이템 클릭 이벤트 구현**
  - `PostContentAdapter`에서 항목 클릭 시 외부 리스너를 통해 클릭된 `Post` 객체 반환
  - 클릭된 보험명을 `ChipGroup`에 Chip으로 추가할 수 있는 구조 제공
- **완료 버튼 활성화 조건 설정 (`updateCompletionButton()`)**
  - `is_Check_Confirmed`, `is_Search_Confirmed` 값이 모두 `true`일 때만 완료 버튼 활성화
  - 조건 만족 시 버튼 배경을 활성화 상태로 변경하고, 미만족 시 비활성화 처리
- **뒤로가기/완료 버튼 전환 함수 구현**
  - **`clickBackButton()`**: 뒤로가기 버튼 클릭 시 이전 화면(`SignUpActivity3`)으로 데이터와 함께 전환
  - **`clickCompletionButton()`**: 완료 버튼 클릭 시 현재까지의 입력 데이터를 다음 화면에 전달하도록 구성
- **초기 진입 시 빈 화면 처리**
  - `PostContentAdapter`의 `filteredList`를 `emptyList()`로 초기화하여 진입 시 항목이 표시되지 않도록 설정
  - 검색이 시작되기 전까지 RecyclerView에 아무 것도 표시되지 않음


### 📄 SignUpActivity3.kt 기능 구현 및 질병 정보 입력 처리 정리
- **회원가입 3단계 화면(`SignUpActivity3.kt`)의 질병 유무 선택 기능 구현**  
  (`CheckBox`를 활용한 질병 없음/유무 항목 선택 구조)

- **사용자 중심 기술을 반영한 질병 입력 UI 설계 및 기능 구현**  
  → `‘질병 없음’(item0)` 체크 시, 다른 질병 항목 자동 비활성화 및 체크 해제  
  → `‘질병 없음’` 해제 시, 나머지 항목 다시 활성화  
  → `item1~item9` 중 하나 이상 선택 시에도 유효 입력으로 간주하여 버튼 활성화

- **체크 상태 기반 유효성 판단 및 시각 피드백 제공**  
  → **Delegates.observable** 기반 상태 추적 (`is_Checked_Confirmed`)  
  → 체크 여부에 따라 `updateNextButton()` 호출로 버튼 활성/비활성 처리 및 컬러 적용

- **화면 복귀 시 체크박스 상태 복원 기능 구현 (restorePassedData)**  
  → `SignUpActivity4.kt`에서 복귀 시 기존 질병 선택값을 유지  
  → `‘질병 없음’` 체크 시에는 나머지 항목을 자동 해제 및 비활성화 처리

- **뒤로가기/다음 화면 이동 시 사용자 정보와 질병 입력값 연계**  
  (`SignUpActivity2.kt ↔ 3 ↔ 4` 간 정보 전달)  
  → 기존 `Map<String, Any>` 기반 사용자 데이터에 `disease0~disease9` 값 포함하여 전송

- **공통화된 버튼 이벤트 처리 함수 활용**  
  → `clickBackButton()`, `clickNextButton()`으로 액티비티 이동 및 데이터 전송 로직 재사용
